### PR TITLE
Add Google Photos Picker service and selection endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Pi Touch HTTP Server
 
 A lightweight Flask-based web server intended for a Raspberry Pi with a touch display.
-It exposes simple HTTP endpoints for turning the screen on/off, starting or stopping a
-Google Photos backed screensaver, and a minimal in-memory publish/subscribe message queue.
+It exposes HTTP endpoints for controlling the display power state, launching a Google
+Photos Picker session, and a minimal in-memory publish/subscribe message queue.
 
 ## Features
-- **Display control:** `/display?cmd=on|off` uses `xset` to control DPMS state.
-- **Screensaver service:** `/screensaver?cmd=on|off` fetches a random image from a
-  Google Photos album named `PiTouch` and displays it using `feh`.
+- **Display control:** `GET /display?cmd=on|off` uses `xset` to toggle the HDMI display.
+- **Google Photos Picker integration:**
+  - `POST /selectPhotos` creates a Picker session, returning a `pickerUri` the user can
+    open in the Google Photos app or web UI. The backend polls the session for up to
+    15 minutes, following the Picker API guidance, and caches the selected media.
+  - `GET /selectPhotos?sessionId=<id>` returns the cached status, including any picked
+    media items once available.
 - **Publish/Subscribe:**
   - `POST /publish` accepts a JSON payload and enqueues it.
   - `GET /subscribe` returns and removes the oldest queued message.
@@ -17,23 +21,42 @@ Google Photos backed screensaver, and a minimal in-memory publish/subscribe mess
 - Python 3
 - Flask
 - requests
-- schedule
-- google-auth, google-auth-oauthlib, google-api-python-client
-- System packages: `feh`, `imagemagick` (for `convert`)
+- google-auth
+- google-auth-oauthlib
 
-These can be installed with:
+Install the Python dependencies with:
+
 ```bash
-pip install flask requests schedule google-auth google-auth-oauthlib google-api-python-client
+pip install flask requests google-auth google-auth-oauthlib
 ```
 
+## Configuring Google Photos Picker OAuth
+1. Create an OAuth 2.0 Client ID (type **Desktop**) in Google Cloud Console.
+2. Download the client configuration JSON and save it as `screensaver/credentials.json`.
+3. Ensure the `screensaver/` directory is writable so the app can persist
+   `picker_token.json` with refreshed tokens.
+4. On first run you will be prompted to complete the OAuth flow. The application requests
+   the `https://www.googleapis.com/auth/photospicker.mediaitems.readonly` scope.
+
 ## Running
-1. Ensure you have Google Photos API credentials in `screensaver/credentials.json` and
-   a writable `screensaver/` directory for tokens and downloaded images.
-2. Start the server:
 ```bash
 python server.py
 ```
+
 The server listens on port **8080** on all interfaces.
+
+## Example Picker workflow
+1. Issue `POST /selectPhotos` with an optional JSON body:
+   ```bash
+   curl -X POST http://<host>:8080/selectPhotos \
+        -H 'Content-Type: application/json' \
+        -d '{"maxItemCount": 25}'
+   ```
+   The response contains the `pickerUri`, a `sessionId`, and a `statusEndpoint`.
+2. Direct the user to open the returned `pickerUri` to choose media.
+3. Poll the status endpoint (or call `GET /selectPhotos?sessionId=<id>`) to monitor the
+   session. Once the user finishes picking, the response will include the selected
+   media items.
 
 ## License
 This project is provided as-is without warranty.

--- a/screensaver.py
+++ b/screensaver.py
@@ -1,126 +1,387 @@
+import copy
+import json
+import logging
 import os
-import random
-import requests
-import schedule
 import threading
 import time
-import pickle
-import subprocess
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
 
-from google.auth.transport.requests import Request
+import requests
+from google.auth.exceptions import RefreshError
+from google.auth.transport.requests import AuthorizedSession, Request
+from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
 
-class Screensaver:
-    def __init__(self):
-        self.running = False
-        self.thread = None
+logger = logging.getLogger(__name__)
 
-    def _run(self):
-        # This method runs in a separate thread
-        while self.running:
-            try: 
-                get_random_photo_and_save()
-            except:
-                print("Screensaver error, this is expected during server initialization")
-            finally:
-                time.sleep(120)  # Wait for 2 minutes before fetching the next photo
 
-    def start(self):
-        if not self.running:
-            self.running = True
-            self.thread = threading.Thread(target=self._run)
-            self.thread.start()
-            print("Screensaver Service started.")
+class PhotosPickerServiceError(Exception):
+    """Base exception raised for Photos Picker service failures."""
 
-    def stop(self):
-        if self.running:
-            self.running = False
-            self.thread.join()  # Wait for the thread to finish
-            print("Screensaver Service stopped.")
 
-# If modifying these scopes, delete the file token.pickle.
-SCOPES = ['https://www.googleapis.com/auth/photoslibrary.readonly']
+class CredentialConfigurationError(PhotosPickerServiceError):
+    """Raised when OAuth credentials are not available."""
 
-def get_service():
-    creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first
-    # time.
-    if os.path.exists('screensaver/token.pickle'):
-        with open('screensaver/token.pickle', 'rb') as token:
-            creds = pickle.load(token)
-    # If there are no (valid) credentials available, let the user log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
+
+class PhotosPickerApiError(PhotosPickerServiceError):
+    """Represents an error returned by the Google Photos Picker API."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, status: Optional[str] = None,
+                 details: Optional[Any] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.status = status
+        self.details = details
+
+
+@dataclass
+class _SessionState:
+    session: Dict[str, Any]
+    state: str
+    created_at: datetime
+    updated_at: datetime
+    last_polled_at: Optional[datetime]
+    completed_at: Optional[datetime]
+    media_items: List[Dict[str, Any]]
+    error: Optional[Dict[str, Any]]
+    deadline: datetime
+    poll_interval_seconds: float
+    request_id: str
+
+
+class PhotosPickerService:
+    """Service wrapper around the Google Photos Picker API."""
+
+    BASE_URL = "https://photospicker.googleapis.com/v1"
+    SCOPES = ["https://www.googleapis.com/auth/photospicker.mediaitems.readonly"]
+    DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+    MAX_POLL_DURATION = timedelta(minutes=15)
+    DEFAULT_TOKEN_FILE = "picker_token.json"
+    DEFAULT_OAUTH_PORT = 8090
+
+    def __init__(self, storage_dir: str = "screensaver", credentials_file: str = "credentials.json",
+                 token_file: Optional[str] = None) -> None:
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        self._storage_dir = os.path.join(base_dir, storage_dir)
+        self._credentials_path = os.path.join(self._storage_dir, credentials_file)
+        token_filename = token_file or self.DEFAULT_TOKEN_FILE
+        self._token_path = os.path.join(self._storage_dir, token_filename)
+        os.makedirs(self._storage_dir, exist_ok=True)
+
+        self._cred_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+
+        self._creds: Optional[Credentials] = None
+        self._states: Dict[str, _SessionState] = {}
+        self._threads: Dict[str, threading.Thread] = {}
+
+    # ------------------------------------------------------------------
+    # OAuth handling
+    # ------------------------------------------------------------------
+    def _load_stored_credentials(self) -> Optional[Credentials]:
+        if not os.path.exists(self._token_path):
+            return None
+        try:
+            with open(self._token_path, "r", encoding="utf-8") as token_file:
+                data = json.load(token_file)
+            return Credentials.from_authorized_user_info(data, self.SCOPES)
+        except (ValueError, TypeError) as exc:
+            logger.warning("Failed to load stored Google Photos Picker credentials: %s", exc)
+            return None
+
+    def _store_credentials(self, creds: Credentials) -> None:
+        with open(self._token_path, "w", encoding="utf-8") as token_file:
+            token_file.write(creds.to_json())
+
+    def _ensure_credentials(self) -> Credentials:
+        with self._cred_lock:
+            creds = self._creds
+            if creds and creds.valid:
+                return creds
+
+            if not creds:
+                creds = self._load_stored_credentials()
+
+            if creds and creds.expired and creds.refresh_token:
+                try:
+                    creds.refresh(Request())
+                except RefreshError as exc:
+                    logger.warning("Failed to refresh Google Photos Picker credentials: %s", exc)
+                    creds = None
+
+            if not creds or not creds.valid:
+                if not os.path.exists(self._credentials_path):
+                    raise CredentialConfigurationError(
+                        f"OAuth client secrets not found at {self._credentials_path}. "
+                        "Ensure the Google Photos Picker credentials are available."
+                    )
+                flow = InstalledAppFlow.from_client_secrets_file(self._credentials_path, self.SCOPES)
+                creds = flow.run_local_server(port=self.DEFAULT_OAUTH_PORT, open_browser=False)
+
+            self._store_credentials(creds)
+            self._creds = creds
+            return creds
+
+    def _authorized_session(self) -> AuthorizedSession:
+        creds = self._ensure_credentials()
+        return AuthorizedSession(creds)
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _duration_to_timedelta(value: Optional[str]) -> Optional[timedelta]:
+        if not value or not isinstance(value, str):
+            return None
+        if not value.endswith("s"):
+            return None
+        try:
+            seconds = float(value[:-1])
+        except ValueError:
+            return None
+        return timedelta(seconds=max(0.0, seconds))
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _register_session(self, session_data: Dict[str, Any], request_id: str,
+                          poll_interval: float, deadline: datetime) -> None:
+        now = self._now()
+        state_value = "COMPLETE" if session_data.get("mediaItemsSet") else "PENDING"
+        completed_at = now if state_value == "COMPLETE" else None
+        with self._state_lock:
+            self._states[session_data["id"]] = _SessionState(
+                session=session_data,
+                state=state_value,
+                created_at=now,
+                updated_at=now,
+                last_polled_at=None,
+                completed_at=completed_at,
+                media_items=[],
+                error=None,
+                deadline=deadline,
+                poll_interval_seconds=poll_interval,
+                request_id=request_id,
+            )
+
+    def _set_state(self, session_id: str, *, session: Optional[Dict[str, Any]] = None,
+                   state: Optional[str] = None, media_items: Optional[List[Dict[str, Any]]] = None,
+                   error: Optional[Dict[str, Any]] = None, last_polled_at: Optional[datetime] = None,
+                   completed_at: Optional[datetime] = None) -> None:
+        now = self._now()
+        with self._state_lock:
+            state_entry = self._states.get(session_id)
+            if not state_entry:
+                return
+            if session is not None:
+                state_entry.session = session
+            if state is not None:
+                state_entry.state = state
+            if media_items is not None:
+                state_entry.media_items = media_items
+            if error is not None:
+                state_entry.error = error
+            if last_polled_at is not None:
+                state_entry.last_polled_at = last_polled_at
+            if completed_at is not None:
+                state_entry.completed_at = completed_at
+            state_entry.updated_at = now
+
+    def _serialize_state(self, session_id: str, state: _SessionState) -> Dict[str, Any]:
+        def _iso(dt: Optional[datetime]) -> Optional[str]:
+            return dt.isoformat() if dt else None
+
+        return {
+            "sessionId": session_id,
+            "state": state.state,
+            "session": copy.deepcopy(state.session),
+            "createdAt": _iso(state.created_at),
+            "updatedAt": _iso(state.updated_at),
+            "lastPolledAt": _iso(state.last_polled_at),
+            "completedAt": _iso(state.completed_at),
+            "pollingDeadline": _iso(state.deadline),
+            "pollIntervalSeconds": state.poll_interval_seconds,
+            "mediaItems": copy.deepcopy(state.media_items),
+            "mediaItemsCount": len(state.media_items),
+            "error": copy.deepcopy(state.error),
+            "requestId": state.request_id,
+        }
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Dict[str, Any]:
+        session = self._authorized_session()
+        url = f"{self.BASE_URL}{path}"
+        kwargs.setdefault("timeout", 30)
+        try:
+            response = session.request(method, url, **kwargs)
+        except requests.exceptions.RequestException as exc:
+            raise PhotosPickerServiceError(
+                f"Failed to call Google Photos Picker API: {exc}" ) from exc
+
+        if response.status_code >= 400:
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {"error": {"message": response.text or "Unknown error"}}
+            error = payload.get("error", {})
+            raise PhotosPickerApiError(
+                error.get("message", "Google Photos Picker API error"),
+                status_code=response.status_code,
+                status=error.get("status"),
+                details=error.get("details"),
+            )
+
+        if not response.content:
+            return {}
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise PhotosPickerServiceError("Failed to parse Google Photos Picker API response.") from exc
+
+    def _fetch_media_items(self, session_id: str) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        page_token: Optional[str] = None
+        while True:
+            params: Dict[str, Any] = {"sessionId": session_id, "pageSize": 100}
+            if page_token:
+                params["pageToken"] = page_token
+            data = self._request("GET", "/mediaItems", params=params)
+            items.extend(data.get("mediaItems", []))
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
+        return items
+
+    def _safe_fetch_media_items(self, session_id: str) -> Optional[List[Dict[str, Any]]]:
+        try:
+            return self._fetch_media_items(session_id)
+        except PhotosPickerApiError as exc:
+            if exc.status == "FAILED_PRECONDITION":
+                return None
+            raise
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def create_session(self, picking_config: Optional[Dict[str, Any]] = None,
+                       request_id: Optional[str] = None) -> Dict[str, Any]:
+        """Create a new picking session and start polling for updates."""
+        if request_id is None:
+            request_id = str(uuid.uuid4())
+        params = {"requestId": request_id}
+        body: Dict[str, Any] = {}
+        if picking_config:
+            body["pickingConfig"] = picking_config
+
+        session_data = self._request("POST", "/sessions", params=params, json=body)
+        session_id = session_data.get("id")
+        if not session_id:
+            raise PhotosPickerServiceError("Session creation response did not include an ID.")
+
+        polling_config = session_data.get("pollingConfig", {}) or {}
+        poll_interval_td = self._duration_to_timedelta(polling_config.get("pollInterval"))
+        poll_interval = poll_interval_td.total_seconds() if poll_interval_td else self.DEFAULT_POLL_INTERVAL_SECONDS
+        poll_interval = max(1.0, poll_interval)
+
+        timeout_td = self._duration_to_timedelta(polling_config.get("timeoutIn"))
+        now = self._now()
+        if timeout_td is None or timeout_td.total_seconds() <= 0:
+            deadline = now + self.MAX_POLL_DURATION
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                'screensaver/credentials.json', SCOPES)
-            creds = flow.run_local_server(port=8080)
-        # Save the credentials for the next run
-        with open('screensaver/token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+            deadline = now + min(timeout_td, self.MAX_POLL_DURATION)
 
-    return build('photoslibrary', 'v1', credentials=creds, static_discovery=False)
+        self._register_session(session_data, request_id, poll_interval, deadline)
 
-def download_image(url, filename):
-    full_resolution_url = url + '=d'  # Append '=d' to get the full resolution image
-    response = requests.get(full_resolution_url)
-    if response.status_code == 200:
-        with open(filename, 'wb') as file:
-            file.write(response.content)
+        if session_data.get("mediaItemsSet"):
+            media_items = self._safe_fetch_media_items(session_id)
+            if media_items is not None:
+                self._set_state(session_id, media_items=media_items, state="COMPLETE",
+                                completed_at=self._now())
+        else:
+            self._start_poll_thread(session_id, poll_interval, deadline)
 
-def get_random_photo_and_save():
-    service = get_service()
-    
-    # List all albums
-    albums_result = service.albums().list(pageSize=50).execute()
-    albums = albums_result.get('albums', [])
-    
-    # Find the specific album by its title
-    target_album_title = 'PiTouch'  
-    target_album_id = None
-    for album in albums:
-        if album['title'] == target_album_title:
-            target_album_id = album['id']
-            break
-    
-    if not target_album_id:
-        print(f'Album "{target_album_title}" not found.')
-        return
-    
-    # List media items in the specific album
-    search_result = service.mediaItems().search(body={
-        'albumId': target_album_id,
-        'pageSize': 100
-    }).execute()
-    
-    items = search_result.get('mediaItems', [])
-    
-    if not items:
-        print(f'No items found in album "{target_album_title}".')
-    else:
-        # Choose a random photo
-        photo = random.choice(items)
-        filename = f"screensaver/photo.jpg"
-        download_image(photo['baseUrl'], filename)
-        print(f'Downloaded {filename}')
-        displayOnScreen()
+        return session_data
 
-def displayOnScreen():
-    subprocess.run(['killall feh'], shell=True)
-    #Resize image to fit 9:16 ratio
-    subprocess.run(['convert screensaver/photo.jpg -resize 1920x1080^ -gravity center -crop 1920x1080+0+0 +repage screensaver/photo.jpg'], shell=True)
-    subprocess.run(['feh --fullscreen --auto-zoom --action1 ";killall feh" --borderless --on-last-slide quit --auto-reload  screensaver/photo.jpg &'], shell=True)
+    def _start_poll_thread(self, session_id: str, poll_interval: float, deadline: datetime) -> None:
+        thread = threading.Thread(
+            target=self._poll_session,
+            args=(session_id, poll_interval, deadline),
+            name=f"photos-picker-poll-{session_id}",
+            daemon=True,
+        )
+        with self._state_lock:
+            self._threads[session_id] = thread
+        thread.start()
+
+    def _poll_session(self, session_id: str, poll_interval: float, deadline: datetime) -> None:
+        end_time = time.monotonic() + max(0.0, (deadline - self._now()).total_seconds())
+        try:
+            while time.monotonic() <= end_time:
+                try:
+                    session_data = self._request("GET", f"/sessions/{session_id}")
+                except PhotosPickerApiError as exc:
+                    error_payload = {"message": str(exc), "status": exc.status, "statusCode": exc.status_code}
+                    self._set_state(session_id, state="ERROR", error=error_payload)
+                    return
+                except PhotosPickerServiceError as exc:
+                    error_payload = {"message": str(exc)}
+                    self._set_state(session_id, state="ERROR", error=error_payload)
+                    return
+
+                now = self._now()
+                self._set_state(session_id, session=session_data, last_polled_at=now)
+
+                if session_data.get("mediaItemsSet"):
+                    try:
+                        media_items = self._safe_fetch_media_items(session_id)
+                    except PhotosPickerServiceError as exc:
+                        error_payload = {"message": str(exc)}
+                        self._set_state(session_id, state="ERROR", error=error_payload)
+                        return
+
+                    if media_items is not None:
+                        self._set_state(session_id, state="COMPLETE", media_items=media_items,
+                                        completed_at=self._now())
+                        return
+
+                sleep_until = min(end_time - time.monotonic(), poll_interval)
+                if sleep_until <= 0:
+                    break
+                time.sleep(sleep_until)
+
+            self._set_state(session_id, state="TIMEOUT")
+        finally:
+            with self._state_lock:
+                self._threads.pop(session_id, None)
+
+    def get_status(self, session_id: str) -> Optional[Dict[str, Any]]:
+        with self._state_lock:
+            state = self._states.get(session_id)
+            if not state:
+                return None
+            return self._serialize_state(session_id, state)
+
+    def delete_session(self, session_id: str) -> None:
+        """Delete a picking session and stop polling."""
+        try:
+            self._request("DELETE", f"/sessions/{session_id}")
+        except PhotosPickerApiError as exc:
+            if exc.status_code == 404:
+                pass
+            else:
+                raise
+        finally:
+            with self._state_lock:
+                self._states.pop(session_id, None)
+                thread = self._threads.pop(session_id, None)
+            if thread and thread.is_alive():
+                # Threads will exit naturally when the state entry is removed.
+                pass
 
 
-
-#schedule.every(2).minutes.do(get_random_photo_and_save)
-#get_random_photo_and_save()
-
-#while True:
-#    schedule.run_pending()
-#    time.sleep(1)
-    
-
+# Backwards compatibility alias for existing imports.
+Screensaver = PhotosPickerService

--- a/server.py
+++ b/server.py
@@ -1,15 +1,22 @@
-import time
-from flask import Flask, request, jsonify, send_from_directory
+import uuid
 from collections import deque
 import subprocess
-import os
-import screensaver
+
+from flask import Flask, jsonify, request, send_from_directory, url_for
+
+from screensaver import (
+    CredentialConfigurationError,
+    PhotosPickerApiError,
+    PhotosPickerService,
+    PhotosPickerServiceError,
+)
 
 app = Flask(__name__)
-service = screensaver.Screensaver()
+picker_service = PhotosPickerService()
 
 # Initialize an in-memory queue using deque from collections for efficient FIFO operations.
 messages_queue = deque()
+
 
 @app.route('/display', methods=['GET'])
 def control_display():
@@ -24,19 +31,82 @@ def control_display():
 
     return f"Display turned {cmd}", 200
 
-@app.route('/screensaver', methods=['GET'])
-def control_screensaver():
-    cmd = request.args.get('cmd')
 
-    if cmd == 'on':
-        #subprocess.run(['feh --fullscreen --auto-zoom --action1 ";killall feh" --borderless --on-last-slide quit --auto-reload  /opt/google-photos-screensaver/photo.jpg &'], shell=True)
-        service.start()
-    elif cmd == 'off':
-        subprocess.run(['killall feh'], shell=True)
-    else:
-        return "Invalid command", 400
+@app.route('/selectPhotos', methods=['POST'])
+def create_selection_session():
+    payload = request.get_json(silent=True) or {}
 
-    return f"Screensaver turned {cmd}", 200
+    request_id_value = payload.get('requestId')
+    if request_id_value:
+        try:
+            request_id_value = str(uuid.UUID(str(request_id_value)))
+        except (ValueError, AttributeError):
+            return jsonify({'error': 'requestId must be a valid UUID string.'}), 400
+
+    picking_config = None
+    if 'maxItemCount' in payload and payload['maxItemCount'] is not None:
+        try:
+            max_items = int(payload['maxItemCount'])
+        except (TypeError, ValueError):
+            return jsonify({'error': 'maxItemCount must be an integer.'}), 400
+        if max_items < 0:
+            return jsonify({'error': 'maxItemCount must be non-negative.'}), 400
+        if max_items > 0:
+            picking_config = {'maxItemCount': str(max_items)}
+
+    try:
+        session_data = picker_service.create_session(
+            picking_config=picking_config,
+            request_id=request_id_value,
+        )
+    except CredentialConfigurationError as exc:
+        return jsonify({'error': str(exc)}), 500
+    except PhotosPickerApiError as exc:
+        error_payload = {'error': str(exc)}
+        if exc.status:
+            error_payload['status'] = exc.status
+        if exc.status_code:
+            error_payload['statusCode'] = exc.status_code
+        if exc.details:
+            error_payload['details'] = exc.details
+        return jsonify(error_payload), 502
+    except PhotosPickerServiceError as exc:
+        return jsonify({'error': str(exc)}), 500
+
+    status_payload = picker_service.get_status(session_data['id'])
+    status_url = url_for('get_selection_session', sessionId=session_data['id'], _external=True)
+
+    response = {
+        'sessionId': session_data['id'],
+        'pickerUri': session_data.get('pickerUri'),
+        'expireTime': session_data.get('expireTime'),
+        'status': status_payload.get('state') if status_payload else 'UNKNOWN',
+        'statusEndpoint': status_url,
+    }
+
+    if status_payload:
+        if status_payload.get('requestId'):
+            response['requestId'] = status_payload['requestId']
+        if status_payload.get('pollingDeadline'):
+            response['pollingDeadline'] = status_payload['pollingDeadline']
+        if status_payload.get('pollIntervalSeconds') is not None:
+            response['pollIntervalSeconds'] = status_payload['pollIntervalSeconds']
+
+    return jsonify(response), 200
+
+
+@app.route('/selectPhotos', methods=['GET'])
+def get_selection_session():
+    session_id = request.args.get('sessionId')
+    if not session_id:
+        return jsonify({'error': 'sessionId query parameter is required.'}), 400
+
+    status_payload = picker_service.get_status(session_id)
+    if not status_payload:
+        return jsonify({'error': 'Session not found.'}), 404
+
+    return jsonify(status_payload), 200
+
 
 @app.route('/publish', methods=['POST'])
 def publish():
@@ -44,6 +114,7 @@ def publish():
     message = request.json
     messages_queue.append(message)
     return jsonify({'status': 'Message added to queue'}), 200
+
 
 @app.route('/subscribe', methods=['GET'])
 def subscribe():
@@ -55,11 +126,11 @@ def subscribe():
         # If the queue is empty, inform the subscriber.
         return jsonify({'status': 'No messages in queue'}), 200
 
+
 @app.route('/')
 def serve_index():
     return send_from_directory('static', 'index.html')
 
+
 if __name__ == "__main__":
-    subprocess.run(['export DISPLAY=:0.0'], shell=True)
-    service.start()
-    app.run(debug=False, port=8080,host='0.0.0.0')
+    app.run(debug=False, port=8080, host='0.0.0.0')


### PR DESCRIPTION
## Summary
- replace the legacy screensaver service with a PhotosPickerService that manages OAuth, session polling, and media retrieval via the Google Photos Picker API
- expose POST/GET `/selectPhotos` endpoints to create sessions, surface picker URIs, and report status while retiring the old `/screensaver` control path
- refresh the README to cover the new picker workflow and dependency requirements

## Testing
- python -m compileall server.py screensaver.py

------
https://chatgpt.com/codex/tasks/task_e_68cdbeee7a30832588aa827585bfce83